### PR TITLE
✨ Add Collection to Project and Reference

### DIFF
--- a/ourprojects/models.py
+++ b/ourprojects/models.py
@@ -19,6 +19,7 @@ from lnschema_core.fields import (
 from lnschema_core.models import (
     Artifact,
     CanCurate,
+    Collection,
     Feature,
     LinkORM,
     Record,
@@ -88,6 +89,10 @@ class Project(Record, CanCurate, TracksRun, TracksUpdates, ValidateFields):
         Artifact, through="ArtifactProject", related_name="projects"
     )
     """Artifacts labeled with this Project."""
+    collections: Collection = models.ManyToManyField(
+        Collection, related_name="projects"
+    )
+    """Collections labeled with this project."""
 
 
 class Reference(Record, CanCurate, TracksRun, TracksUpdates, ValidateFields):
@@ -159,6 +164,10 @@ class Reference(Record, CanCurate, TracksRun, TracksUpdates, ValidateFields):
         Artifact, through="ArtifactReference", related_name="references"
     )
     """Artifacts labeled with this reference."""
+    collections: Collection = models.ManyToManyField(
+        Collection, related_name="references"
+    )
+    """Collections labeled with this reference."""
 
 
 class ArtifactReference(Record, LinkORM, TracksRun):


### PR DESCRIPTION
Coming out of a discussion with Sunny.

1. References are defined on a Collection level for CxG. 
2. We don't have a way to sync References between Artifact and Collection. Therefore we have decided not to also add them on the Collection level.

This PR is blocked until we have discussed this topic further.